### PR TITLE
Change device class of wind direction

### DIFF
--- a/custom_components/ws980wifi/manifest.json
+++ b/custom_components/ws980wifi/manifest.json
@@ -3,8 +3,8 @@
   "name": "ELV WS980WiFi ",
   "documentation": "https://github.com/patschbo/ws980wifi/",
   "dependencies": [],
-  "codeowners": ["@eXtgmA", "@patschbo", "@diefraschw"],
+  "codeowners": ["@eXtgmA", "@patschbo", "@diefraschw", "@lambnoah99"],
   "requirements": [],
-  "version": "0.1.12",
+  "version": "0.1.13",
   "integration_type": "hub"
 }

--- a/custom_components/ws980wifi/sensor.py
+++ b/custom_components/ws980wifi/sensor.py
@@ -18,6 +18,11 @@
 #       correct regular expression for dew point (dew.point instead of dew_point)
 #       adapt version to higher version of patschbo
 #       remove unnecessary comments
+#
+#   v0.1.13
+#       correct device-class for wind_direction
+#
+
 
 import logging
 import select
@@ -57,7 +62,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/ws980wifi/sensor.py
+++ b/custom_components/ws980wifi/sensor.py
@@ -175,7 +175,7 @@ SENSOR_PROPERTIES = {
         "32",
         "2",
         "1",
-        SensorStateClass.MEASUREMENT,
+        SensorStateClass.MEASUREMENT_ANGLE,
     ],
     "wind_speed": [
         "wind speed",

--- a/custom_components/ws980wifi/sensor.py
+++ b/custom_components/ws980wifi/sensor.py
@@ -166,7 +166,7 @@ SENSOR_PROPERTIES = {
     "wind_direction": [
         "wind direction",
         DEGREE,
-        None,
+        SensorDeviceClass.WIND_DIRECTION,
         "32",
         "2",
         "1",

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "WS980WIFI",
   "hide_default_branch": true,
-  "homeassistant": "2022.7.0",
-  "hacs": "0.19.0",
+  "homeassistant": "2025.3.0",
+  "hacs": "0.19.0"
 }


### PR DESCRIPTION
- Changes the device-class of wind_direction from `None` to `SensorDeviceClass.WIND_DIRECTION`.
- Increments Version
- Changes mininum required home-assistant version for hacs.